### PR TITLE
Follow more closely what is done in the atpackager plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,16 @@
 var through = require('through2');
 var findRequires = require('noder-js/findRequires');
+var moduleFunction = String(require('noder-js/context').prototype.jsModuleEval("$CONTENT$"));
 var path = require('path');
 
 module.exports.package = function (basePath) {
 
     return through.obj(function (file, encoding, done) {
         var fileContent = String(file.contents);
-        var requires = findRequires(fileContent);
-        var requiresStr = requires.length ? '"' + requires.join('", "') + '"' : '';
+        var requires = findRequires(fileContent, true);
         var filePath = path.relative(__dirname + '/../..' + (basePath || ''), file.path);
-        file.contents = new Buffer([
-            '\tdefine("' + filePath + '", [' + requiresStr + '], function(module, global) {',
-            '\t\tvar require = module.require, exports = module.exports, __filename = module.filename, __dirname = module.dirname;',
-            fileContent,
-            '\t});'].join('\n'));
-
+        file.contents = new Buffer(['define(', JSON.stringify(filePath), ', ', JSON.stringify(requires) + ', ',
+                moduleFunction.replace("$CONTENT$", fileContent), ');'].join(''));
         this.push(file);
         done();
     });


### PR DESCRIPTION
This pull request changes 2 items to follow more closely what is done in the [noder atpackager plugin](https://github.com/ariatemplates/noder-js/blob/master/build/builders/NoderPackage.js):
- instead of including the module definition function skeleton, it uses the one from `noder-js`, so that if it changes in a future noder-js release, this plugin will not have to be updated
- `findRequires` is called with `true` as the second parameter so that code using loader plugins is properly packaged (for more information about loader plugins, read the loader plugins section of the [noder-js documentation](http://noder-js.ariatemplates.com/api.html)).
