### PR TITLE
Fixing issue with `$$` in file content

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports.package = function (basePath) {
         var requires = findRequires(fileContent, true);
         var filePath = path.relative(__dirname + '/../..' + (basePath || ''), file.path).replace(/\\/g, '/');
         file.contents = new Buffer(['define(', JSON.stringify(filePath), ', ', JSON.stringify(requires) + ', ',
-                moduleFunction.replace("$CONTENT$", fileContent), ');'].join(''));
+                moduleFunction.replace("$CONTENT$", function () { return fileContent; } ), ');'].join(''));
         this.push(file);
         done();
     });


### PR DESCRIPTION
If a file to be packaged with gulp-noder contains `$$` (or other special replacement patterns), it is mistakenly replaced with `$` (or some other value), because of the special behavior of the string `replace` method, as documented [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter)
